### PR TITLE
feat: always-visible bet instructions on opportunity cards

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -6,7 +6,7 @@ export default async function DashboardPage() {
   const { data: { user } } = await supabase.auth.getUser()
 
   const [{ data: opportunities }, { data: bets }] = await Promise.all([
-    supabase.from('opportunities').select('*').eq('user_id', user!.id).eq('is_active', true).order('roi_percentage', { ascending: false }),
+    supabase.from('opportunities').select('*, promotions(name, amount)').eq('user_id', user!.id).eq('is_active', true).order('roi_percentage', { ascending: false }),
     supabase.from('bets').select('profit_loss, status').eq('user_id', user!.id).in('status', ['won', 'lost']),
   ])
 

--- a/components/opportunities/OpportunityCard.tsx
+++ b/components/opportunities/OpportunityCard.tsx
@@ -1,29 +1,11 @@
 'use client'
-import { useState } from 'react'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { toast } from 'sonner'
-import { getTypeAccent, getTypeBadge } from '@/lib/opportunities/typeAccent'
-
-interface Opportunity {
-  id: string
-  opportunity_type: string
-  event_name: string
-  commence_time: string
-  sport_key: string
-  leg1_bookmaker: string
-  leg1_outcome: string
-  leg1_odds: number
-  leg1_stake: number
-  leg2_bookmaker?: string | null
-  leg2_outcome?: string | null
-  leg2_odds?: number | null
-  leg2_stake?: number | null
-  guaranteed_profit?: number | null
-  expected_value?: number | null
-  roi_percentage: number
-}
+import { getTypeAccent, getTypeBadge, getLegLabels } from '@/lib/opportunities/typeAccent'
+import { decimalToAmerican } from '@/lib/calculator/utils'
+import type { Opportunity } from './types'
 
 const TYPE_LABELS: Record<string, string> = {
   free_bet_conversion: 'Free Bet',
@@ -42,13 +24,46 @@ const EV_TYPES = new Set(['free_bet_ev', 'boost_ev', 'odds_boost_ev', 'line_valu
 function isArb(type: string) { return ARB_TYPES.has(type) }
 function isEV(type: string) { return EV_TYPES.has(type) }
 
+function getCountdown(commenceTime: string): string | null {
+  const diff = new Date(commenceTime).getTime() - Date.now()
+  if (isNaN(diff) || diff <= 0) return null
+  if (diff > 24 * 60 * 60 * 1000) return null
+  const h = Math.floor(diff / 3600000)
+  const m = Math.floor((diff % 3600000) / 60000)
+  return h > 0 ? `${h}h ${m}m` : `${m}m`
+}
+
+async function copyText(text: string, label: string) {
+  try {
+    await navigator.clipboard.writeText(text)
+    toast.success(`${label} copied!`)
+  } catch {
+    toast.error(`Copy failed — ${text}`)
+  }
+}
+
 export function OpportunityCard({ opp, onLogBet }: { opp: Opportunity; onLogBet?: (opp: Opportunity) => void }) {
-  const [expanded, setExpanded] = useState(false)
   const hasTwoLegs = !!opp.leg2_bookmaker
   const evType = isEV(opp.opportunity_type)
   const arbType = isArb(opp.opportunity_type)
+  const legLabels = getLegLabels(opp.opportunity_type)
+  const countdown = getCountdown(opp.commence_time)
 
-  function copyBetSlip() {
+  const typeAccent = getTypeAccent(opp.opportunity_type)
+  const typeBadge = getTypeBadge(opp.opportunity_type)
+
+  function copyLeg1() {
+    const text = `${opp.leg1_bookmaker.toUpperCase()}: ${opp.leg1_outcome} @ ${decimalToAmerican(opp.leg1_odds)} — $${opp.leg1_stake.toFixed(2)}`
+    copyText(text, opp.leg1_bookmaker.toUpperCase())
+  }
+
+  function copyLeg2() {
+    if (!hasTwoLegs) return
+    const text = `${opp.leg2_bookmaker!.toUpperCase()}: ${opp.leg2_outcome} @ ${decimalToAmerican(opp.leg2_odds!)} — $${opp.leg2_stake!.toFixed(2)}`
+    copyText(text, opp.leg2_bookmaker!.toUpperCase())
+  }
+
+  function copySlip() {
     const lines = [
       `=== ${evType ? '+EV Play' : 'Arb'}: ${opp.event_name} ===`,
       `Type: ${TYPE_LABELS[opp.opportunity_type] ?? opp.opportunity_type}`,
@@ -56,17 +71,11 @@ export function OpportunityCard({ opp, onLogBet }: { opp: Opportunity; onLogBet?
       arbType && opp.guaranteed_profit != null ? `Guaranteed Profit: $${opp.guaranteed_profit.toFixed(2)}` : '',
       evType && opp.expected_value != null ? `Expected Value: $${opp.expected_value.toFixed(2)}` : '',
       '',
-      `Leg 1: ${opp.leg1_bookmaker.toUpperCase()} — ${opp.leg1_outcome}`,
-      `  Odds: ${opp.leg1_odds.toFixed(3)} | Stake: $${opp.leg1_stake.toFixed(2)}`,
-      hasTwoLegs ? `\nLeg 2: ${opp.leg2_bookmaker!.toUpperCase()} — ${opp.leg2_outcome}` : '',
-      hasTwoLegs ? `  Odds: ${opp.leg2_odds!.toFixed(3)} | Stake: $${opp.leg2_stake!.toFixed(2)}` : '',
+      `${hasTwoLegs ? 'STEP 1' : 'BET'}  ${opp.leg1_bookmaker.toUpperCase()}: ${opp.leg1_outcome} @ ${decimalToAmerican(opp.leg1_odds)} — $${opp.leg1_stake.toFixed(2)}`,
+      hasTwoLegs ? `STEP 2  ${opp.leg2_bookmaker!.toUpperCase()}: ${opp.leg2_outcome} @ ${decimalToAmerican(opp.leg2_odds!)} — $${opp.leg2_stake!.toFixed(2)}` : '',
     ].filter(Boolean).join('\n')
-    navigator.clipboard.writeText(lines)
-    toast.success('Bet slip copied!')
+    copyText(lines, 'Bet slip')
   }
-
-  const typeAccent = getTypeAccent(opp.opportunity_type)
-  const typeBadge = getTypeBadge(opp.opportunity_type)
 
   return (
     <Card className={`border-l-4 ${typeAccent} hover:scale-[1.01] transition-transform duration-150`}>
@@ -91,48 +100,78 @@ export function OpportunityCard({ opp, onLogBet }: { opp: Opportunity; onLogBet?
           <p className="text-2xl font-bold tabular-nums text-win">+${opp.guaranteed_profit.toFixed(2)} guaranteed</p>
         )}
         {evType && opp.expected_value != null && (
-          <div>
-            <p className="text-2xl font-bold tabular-nums text-ev">+${opp.expected_value.toFixed(2)} expected</p>
-            {!hasTwoLegs && (
-              <p className="text-xs text-muted-foreground">
-                {opp.leg1_bookmaker.toUpperCase()} · {opp.leg1_outcome} @ {opp.leg1_odds.toFixed(3)}
-              </p>
+          <p className="text-2xl font-bold tabular-nums text-ev">+${opp.expected_value.toFixed(2)} expected</p>
+        )}
+
+        {/* Leg 1 */}
+        <div className="rounded-md bg-secondary p-3 space-y-1">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                {hasTwoLegs ? 'Step 1' : 'Bet'}
+              </span>
+              <span className="text-sm font-semibold">{opp.leg1_bookmaker.toUpperCase()}</span>
+            </div>
+            {opp.promotions?.name && (
+              <span className="text-xs text-muted-foreground">Using: {opp.promotions.name}</span>
             )}
           </div>
-        )}
+          <p className="font-medium">{opp.leg1_outcome}</p>
+          <div className="flex items-center justify-between">
+            <p className="text-sm tabular-nums text-muted-foreground">
+              <strong className="text-foreground">{decimalToAmerican(opp.leg1_odds)}</strong>
+              {' · '}
+              <strong className="text-foreground">${opp.leg1_stake.toFixed(2)}</strong>
+              {' · '}
+              {legLabels.leg1}
+            </p>
+            <Button size="sm" variant="ghost" className="h-6 px-2 text-xs" onClick={copyLeg1}>
+              Copy
+            </Button>
+          </div>
+        </div>
 
-        {expanded && (
-          <div className="space-y-2 text-sm border-t border-border pt-3">
-            <div className={`grid gap-2 ${hasTwoLegs ? 'grid-cols-2' : 'grid-cols-1'}`}>
-              <div className="bg-secondary rounded p-2">
-                <p className="text-xs text-muted-foreground mb-1">Leg 1 — {opp.leg1_bookmaker.toUpperCase()}</p>
-                <p className="font-medium">{opp.leg1_outcome}</p>
-                <p className="tabular-nums">Odds: <strong>{opp.leg1_odds.toFixed(3)}</strong></p>
-                <p className="tabular-nums">Stake: <strong>${opp.leg1_stake.toFixed(2)}</strong></p>
+        {/* Leg 2 */}
+        {hasTwoLegs && (
+          <div className="rounded-md bg-secondary p-3 space-y-1">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Step 2</span>
+                <span className="text-sm font-semibold">{opp.leg2_bookmaker!.toUpperCase()}</span>
               </div>
-              {hasTwoLegs && (
-                <div className="bg-secondary rounded p-2">
-                  <p className="text-xs text-muted-foreground mb-1">Leg 2 — {opp.leg2_bookmaker!.toUpperCase()}</p>
-                  <p className="font-medium">{opp.leg2_outcome}</p>
-                  <p className="tabular-nums">Odds: <strong>{opp.leg2_odds!.toFixed(3)}</strong></p>
-                  <p className="tabular-nums">Stake: <strong>${opp.leg2_stake!.toFixed(2)}</strong></p>
-                </div>
+              {countdown && (
+                <span className="text-xs text-amber-500 font-medium">{countdown} left</span>
               )}
             </div>
-            <div className="flex gap-2">
-              <Button size="sm" variant="outline" onClick={copyBetSlip}>
-                {hasTwoLegs ? 'Copy Slip' : 'Copy Bet'}
+            <p className="font-medium">{opp.leg2_outcome}</p>
+            <div className="flex items-center justify-between">
+              <p className="text-sm tabular-nums text-muted-foreground">
+                <strong className="text-foreground">{decimalToAmerican(opp.leg2_odds!)}</strong>
+                {' · '}
+                <strong className="text-foreground">${opp.leg2_stake!.toFixed(2)}</strong>
+                {' · '}
+                {legLabels.leg2}
+              </p>
+              <Button size="sm" variant="ghost" className="h-6 px-2 text-xs" onClick={copyLeg2}>
+                Copy
               </Button>
-              {onLogBet && (
-                <Button size="sm" onClick={() => onLogBet(opp)}>Log Bet</Button>
-              )}
             </div>
           </div>
         )}
 
-        <Button variant="ghost" size="sm" className="w-full text-xs" onClick={() => setExpanded(!expanded)}>
-          {expanded ? 'Collapse' : 'Show Details'}
-        </Button>
+        {/* For single-leg +EV: show countdown on the leg itself */}
+        {!hasTwoLegs && countdown && (
+          <p className="text-xs text-amber-500 font-medium">{countdown} left</p>
+        )}
+
+        <div className="flex gap-2 pt-1">
+          <Button size="sm" variant="outline" onClick={copySlip}>
+            {hasTwoLegs ? 'Copy Slip' : 'Copy Bet'}
+          </Button>
+          {onLogBet && (
+            <Button size="sm" onClick={() => onLogBet(opp)}>Log Bet</Button>
+          )}
+        </div>
       </CardContent>
     </Card>
   )

--- a/components/opportunities/OpportunityFeed.tsx
+++ b/components/opportunities/OpportunityFeed.tsx
@@ -3,25 +3,7 @@ import { useState, useCallback } from 'react'
 import { OpportunityCard } from './OpportunityCard'
 import { Button } from '@/components/ui/button'
 import { toast } from 'sonner'
-
-interface Opportunity {
-  id: string
-  opportunity_type: string
-  event_name: string
-  commence_time: string
-  sport_key: string
-  leg1_bookmaker: string
-  leg1_outcome: string
-  leg1_odds: number
-  leg1_stake: number
-  leg2_bookmaker?: string | null
-  leg2_outcome?: string | null
-  leg2_odds?: number | null
-  leg2_stake?: number | null
-  guaranteed_profit?: number | null
-  expected_value?: number | null
-  roi_percentage: number
-}
+import type { Opportunity } from './types'
 
 type FilterTab = 'all' | 'arb' | 'ev' | 'promo_ev'
 

--- a/components/opportunities/types.ts
+++ b/components/opportunities/types.ts
@@ -1,0 +1,19 @@
+export interface Opportunity {
+  id: string
+  opportunity_type: string
+  event_name: string
+  commence_time: string
+  sport_key: string
+  leg1_bookmaker: string
+  leg1_outcome: string
+  leg1_odds: number
+  leg1_stake: number
+  leg2_bookmaker?: string | null
+  leg2_outcome?: string | null
+  leg2_odds?: number | null
+  leg2_stake?: number | null
+  guaranteed_profit?: number | null
+  expected_value?: number | null
+  roi_percentage: number
+  promotions?: { name: string; amount: number } | null
+}

--- a/lib/calculator/__tests__/utils.test.ts
+++ b/lib/calculator/__tests__/utils.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { decimalToAmerican } from '../utils'
+
+describe('decimalToAmerican', () => {
+  it('returns +150 for decimal 2.5', () => {
+    expect(decimalToAmerican(2.5)).toBe('+150')
+  })
+
+  it('returns -200 for decimal 1.5', () => {
+    expect(decimalToAmerican(1.5)).toBe('-200')
+  })
+
+  it('returns +100 for decimal 2.0', () => {
+    expect(decimalToAmerican(2.0)).toBe('+100')
+  })
+
+  it('returns N/A for decimal 1.0', () => {
+    expect(decimalToAmerican(1.0)).toBe('N/A')
+  })
+
+  it('returns N/A for decimal 0.5', () => {
+    expect(decimalToAmerican(0.5)).toBe('N/A')
+  })
+})

--- a/lib/calculator/utils.ts
+++ b/lib/calculator/utils.ts
@@ -3,6 +3,12 @@ export function americanToDecimal(american: number): number {
   return 100 / Math.abs(american) + 1
 }
 
+export function decimalToAmerican(decimal: number): string {
+  if (decimal <= 1) return 'N/A'
+  if (decimal >= 2) return `+${Math.round((decimal - 1) * 100)}`
+  return `${Math.round(-100 / (decimal - 1))}`
+}
+
 export function noVigProbability(decimalOdds: number[]): number[] {
   const implied = decimalOdds.map(o => 1 / o)
   const total = implied.reduce((a, b) => a + b, 0)

--- a/lib/opportunities/typeAccent.test.ts
+++ b/lib/opportunities/typeAccent.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getTypeAccent, getTypeBadge } from './typeAccent'
+import { getTypeAccent, getTypeBadge, getLegLabels } from './typeAccent'
 
 describe('getTypeAccent', () => {
   it('arb types get violet accent', () => {
@@ -35,5 +35,43 @@ describe('getTypeBadge', () => {
 
   it('pure EV types get ev badge', () => {
     expect(getTypeBadge('line_value')).toContain('ev')
+  })
+})
+
+describe('getLegLabels', () => {
+  it('free_bet_conversion: Free Bet Token + Cash Hedge', () => {
+    expect(getLegLabels('free_bet_conversion')).toEqual({ leg1: 'Free Bet Token', leg2: 'Cash Hedge' })
+  })
+
+  it('profit_boost_arb: Cash (Boosted) + Cash Hedge', () => {
+    expect(getLegLabels('profit_boost_arb')).toEqual({ leg1: 'Cash (Boosted)', leg2: 'Cash Hedge' })
+  })
+
+  it('true_arb: Cash + Cash Hedge', () => {
+    expect(getLegLabels('true_arb')).toEqual({ leg1: 'Cash', leg2: 'Cash Hedge' })
+  })
+
+  it('no_sweat_arb: No Sweat Bet + Cash Hedge', () => {
+    expect(getLegLabels('no_sweat_arb')).toEqual({ leg1: 'No Sweat Bet', leg2: 'Cash Hedge' })
+  })
+
+  it('free_bet_ev: Free Bet Token + null', () => {
+    expect(getLegLabels('free_bet_ev')).toEqual({ leg1: 'Free Bet Token', leg2: null })
+  })
+
+  it('boost_ev: Cash (Boosted) + null', () => {
+    expect(getLegLabels('boost_ev')).toEqual({ leg1: 'Cash (Boosted)', leg2: null })
+  })
+
+  it('odds_boost_ev: Cash (Boosted) + null', () => {
+    expect(getLegLabels('odds_boost_ev')).toEqual({ leg1: 'Cash (Boosted)', leg2: null })
+  })
+
+  it('line_value: Cash + null', () => {
+    expect(getLegLabels('line_value')).toEqual({ leg1: 'Cash', leg2: null })
+  })
+
+  it('unknown type falls back to Cash + null', () => {
+    expect(getLegLabels('unknown_type')).toEqual({ leg1: 'Cash', leg2: null })
   })
 })

--- a/lib/opportunities/typeAccent.ts
+++ b/lib/opportunities/typeAccent.ts
@@ -14,3 +14,18 @@ export function getTypeBadge(type: string): string {
   if (PROMO_EV_TYPES.has(type)) return 'bg-promo/15 text-promo'
   return 'bg-ev/15 text-ev'
 }
+
+/** Returns per-leg wager type labels for a given opportunity type. */
+export function getLegLabels(type: string): { leg1: string; leg2: string | null } {
+  switch (type) {
+    case 'free_bet_conversion': return { leg1: 'Free Bet Token', leg2: 'Cash Hedge' }
+    case 'profit_boost_arb':    return { leg1: 'Cash (Boosted)', leg2: 'Cash Hedge' }
+    case 'true_arb':            return { leg1: 'Cash',           leg2: 'Cash Hedge' }
+    case 'no_sweat_arb':        return { leg1: 'No Sweat Bet',   leg2: 'Cash Hedge' }
+    case 'free_bet_ev':         return { leg1: 'Free Bet Token', leg2: null }
+    case 'boost_ev':            return { leg1: 'Cash (Boosted)', leg2: null }
+    case 'odds_boost_ev':       return { leg1: 'Cash (Boosted)', leg2: null }
+    case 'line_value':          return { leg1: 'Cash',           leg2: null }
+    default:                    return { leg1: 'Cash',           leg2: null }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arb-dashboard2-temp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- **Always-visible bet instructions** — removed the expand/collapse toggle; every card immediately shows book, outcome, American odds, stake, and wager type label
- **American odds** — decimal odds converted to US format (+150, -165) via new `decimalToAmerican()` utility
- **Per-leg Copy buttons** — each leg has a Copy button that writes `BOOK: outcome @ +ODDS — $STAKE` to clipboard
- **Promo name display** — cards show "Using: [promo name]" on leg 1 when a promo is linked (via `promotions(name, amount)` JOIN)
- **Countdown timer** — events within 24h show "Xh Ym left" on the hedge leg
- **Log Bet on card face** — moved from hidden expand section to always-visible
- **Shared `Opportunity` type** — extracted from two files into `components/opportunities/types.ts` (DRY)
- **`getLegLabels()`** — per-leg wager type labels for all 8 opportunity types

## Pre-Landing Review

Pre-Landing Review: 0 critical, 2 informational (non-blocking)
- `types.ts` and `utils.test.ts` were untracked at review time — staged and committed before ship
- `copySlip` doesn't include promo name in copied text (card UI does show it) — minor, deferred

## Eval Results

No prompt-related files changed — evals skipped.

## TODOS

No TODO items completed in this PR.

## Test plan

- [x] All Vitest tests pass (49 tests, 5 suites)
- [x] New: `decimalToAmerican` — 5 cases covering +EV, -EV, even, and N/A boundaries
- [x] New: `getLegLabels` — 9 cases covering all 8 opportunity types + default fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)