### PR TITLE
fix: client-side exception after opportunity card rewrite (v0.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.2] - 2026-03-17
+
+### Fixed
+- Hydration mismatch crash: moved `getCountdown()` (which calls `Date.now()`) from render-time into a `useEffect` so the server always renders null and the client sets the value after hydration
+- Empty dashboard caused by PostgREST 400 error: `promotions(name, amount)` select was querying a non-existent `name` column — changed to `promotions(sportsbook, amount)` to match the actual schema
+- Latent crash in Leg 2 block: replaced `!` non-null assertions on `leg2_stake` and `leg2_odds` with `?? 0` / `?? 1` fallbacks so null values don't crash `toFixed()`
+
+## [0.1.1] - 2026-03-15
+
+### Added
+- Tests for `decimalToAmerican` and `getLegLabels` utilities
+- Always-visible bet instructions on opportunity cards (Leg 1 + Leg 2 blocks always rendered, no expand toggle)
+- Shared `Opportunity` type, `decimalToAmerican`, and `getLegLabels` utilities
+- `+EV` betting opportunity types: `free_bet_ev`, `boost_ev`, `odds_boost_ev`, `line_value`
+- Pinnacle fair odds two-pass calculator
+- Supabase-inspired color palette with green-hued dark bg and electric blue CTAs

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -6,7 +6,7 @@ export default async function DashboardPage() {
   const { data: { user } } = await supabase.auth.getUser()
 
   const [{ data: opportunities }, { data: bets }] = await Promise.all([
-    supabase.from('opportunities').select('*, promotions(name, amount)').eq('user_id', user!.id).eq('is_active', true).order('roi_percentage', { ascending: false }),
+    supabase.from('opportunities').select('*, promotions(sportsbook, amount)').eq('user_id', user!.id).eq('is_active', true).order('roi_percentage', { ascending: false }),
     supabase.from('bets').select('profit_loss, status').eq('user_id', user!.id).in('status', ['won', 'lost']),
   ])
 

--- a/components/opportunities/OpportunityCard.tsx
+++ b/components/opportunities/OpportunityCard.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { useState, useEffect } from 'react'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -47,7 +48,10 @@ export function OpportunityCard({ opp, onLogBet }: { opp: Opportunity; onLogBet?
   const evType = isEV(opp.opportunity_type)
   const arbType = isArb(opp.opportunity_type)
   const legLabels = getLegLabels(opp.opportunity_type)
-  const countdown = getCountdown(opp.commence_time)
+  const [countdown, setCountdown] = useState<string | null>(null)
+  useEffect(() => {
+    setCountdown(getCountdown(opp.commence_time))
+  }, [opp.commence_time])
 
   const typeAccent = getTypeAccent(opp.opportunity_type)
   const typeBadge = getTypeBadge(opp.opportunity_type)
@@ -72,7 +76,7 @@ export function OpportunityCard({ opp, onLogBet }: { opp: Opportunity; onLogBet?
       evType && opp.expected_value != null ? `Expected Value: $${opp.expected_value.toFixed(2)}` : '',
       '',
       `${hasTwoLegs ? 'STEP 1' : 'BET'}  ${opp.leg1_bookmaker.toUpperCase()}: ${opp.leg1_outcome} @ ${decimalToAmerican(opp.leg1_odds)} — $${opp.leg1_stake.toFixed(2)}`,
-      hasTwoLegs ? `STEP 2  ${opp.leg2_bookmaker!.toUpperCase()}: ${opp.leg2_outcome} @ ${decimalToAmerican(opp.leg2_odds!)} — $${opp.leg2_stake!.toFixed(2)}` : '',
+      hasTwoLegs ? `STEP 2  ${opp.leg2_bookmaker!.toUpperCase()}: ${opp.leg2_outcome} @ ${decimalToAmerican(opp.leg2_odds ?? 1)} — $${(opp.leg2_stake ?? 0).toFixed(2)}` : '',
     ].filter(Boolean).join('\n')
     copyText(lines, 'Bet slip')
   }
@@ -112,8 +116,8 @@ export function OpportunityCard({ opp, onLogBet }: { opp: Opportunity; onLogBet?
               </span>
               <span className="text-sm font-semibold">{opp.leg1_bookmaker.toUpperCase()}</span>
             </div>
-            {opp.promotions?.name && (
-              <span className="text-xs text-muted-foreground">Using: {opp.promotions.name}</span>
+            {opp.promotions?.sportsbook && (
+              <span className="text-xs text-muted-foreground">Using: {opp.promotions.sportsbook}</span>
             )}
           </div>
           <p className="font-medium">{opp.leg1_outcome}</p>
@@ -146,9 +150,9 @@ export function OpportunityCard({ opp, onLogBet }: { opp: Opportunity; onLogBet?
             <p className="font-medium">{opp.leg2_outcome}</p>
             <div className="flex items-center justify-between">
               <p className="text-sm tabular-nums text-muted-foreground">
-                <strong className="text-foreground">{decimalToAmerican(opp.leg2_odds!)}</strong>
+                <strong className="text-foreground">{decimalToAmerican(opp.leg2_odds ?? 1)}</strong>
                 {' · '}
-                <strong className="text-foreground">${opp.leg2_stake!.toFixed(2)}</strong>
+                <strong className="text-foreground">${(opp.leg2_stake ?? 0).toFixed(2)}</strong>
                 {' · '}
                 {legLabels.leg2}
               </p>

--- a/components/opportunities/types.ts
+++ b/components/opportunities/types.ts
@@ -15,5 +15,5 @@ export interface Opportunity {
   guaranteed_profit?: number | null
   expected_value?: number | null
   roi_percentage: number
-  promotions?: { name: string; amount: number } | null
+  promotions?: { sportsbook: string; amount: number } | null
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arb-dashboard2-temp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- **Hydration crash (PRIMARY):** Moved `getCountdown()` (calls `Date.now()`) out of render into `useEffect` — server always renders null, client sets countdown after hydration. Eliminates React 19 hydration mismatch fatal error.
- **Empty dashboard:** `promotions(name, amount)` queried a non-existent `name` column, causing PostgREST HTTP 400 → `data: null` → zero opportunities shown. Fixed to `promotions(sportsbook, amount)`.
- **Latent leg2 crash:** `leg2_stake!.toFixed()` / `decimalToAmerican(leg2_odds!)` now always rendered (no expand toggle). Replaced `!` assertions with `?? 0` / `?? 1` fallbacks.

## Pre-Landing Review
No issues found.

## Eval Results
No prompt-related files changed — evals skipped.

## TODOS
No TODO items completed in this PR.

## Test plan
- [x] All Vitest tests pass (49 tests, 5 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)