### PR TITLE
Auto-expire promotions past their expiry date on fetch

### DIFF
--- a/app/api/promos/route.ts
+++ b/app/api/promos/route.ts
@@ -6,6 +6,14 @@ export async function GET() {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
+  // Auto-expire any promos whose expiry date has passed
+  await supabase
+    .from('promotions')
+    .update({ status: 'expired' })
+    .eq('user_id', user.id)
+    .in('status', ['available', 'pending'])
+    .lt('expires_at', new Date().toISOString())
+
   const { data } = await supabase
     .from('promotions')
     .select('*')


### PR DESCRIPTION
Before returning promotions, update any available/pending promos
whose expires_at has passed to status='expired' so they automatically
appear in the Expired tab on the Promotions page.

https://claude.ai/code/session_01Vc1rBN1YKWkNeyHK4ktKZY