### PR TITLE
Auto-refresh odds on page load and every 5 minutes

### DIFF
--- a/components/opportunities/OpportunityFeed.tsx
+++ b/components/opportunities/OpportunityFeed.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { OpportunityCard } from './OpportunityCard'
 import { Button } from '@/components/ui/button'
 import { toast } from 'sonner'
@@ -64,6 +64,12 @@ export function OpportunityFeed({ initialOpportunities }: Props) {
       setLoading(false)
     }
   }, [])
+
+  useEffect(() => {
+    refresh()
+    const interval = setInterval(refresh, 5 * 60 * 1000)
+    return () => clearInterval(interval)
+  }, [refresh])
 
   const filtered = filterByTab(opportunities, activeTab)
   const counts = {


### PR DESCRIPTION
## Summary
- Trigger odds refresh automatically when `OpportunityFeed` mounts — no manual button click needed on page load
- Re-fetch every 5 minutes via `setInterval` to keep opportunities current
- Interval is cleaned up on unmount to avoid memory leaks

## Test plan
- [ ] Navigate to dashboard — odds should refresh automatically without clicking "Refresh Odds"
- [ ] Leave page open for 5+ minutes — odds should refresh again automatically

https://claude.ai/code/session_01Vc1rBN1YKWkNeyHK4ktKZY